### PR TITLE
Add bg-color to no-matches drop-down

### DIFF
--- a/src/CountrySelect/OverlayContent/style.scss
+++ b/src/CountrySelect/OverlayContent/style.scss
@@ -7,7 +7,7 @@
   overflow-y: scroll;
 
   .country-select__no-matches {
-
+    background-color: #fff;
     padding: $list-item-padding;
     color: $gray-600;
 


### PR DESCRIPTION
Currently, the no-matches drop-down does not have a background color. If there is any content below the selector, the no-matches text will be mixed with the component under it.