### PR TITLE
Support higher versions of react-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "react": ">=17.0.2",
-    "react-bootstrap": "^1.6.1",
+    "react-bootstrap": "^1.6.1 - ^2.4.0",
     "react-dom": ">=17.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Thank you so much for your package!

I am using your package in a project that includes `react-bootstrap 2.4.x` and it works great. But I have to include `--legacy-peer-deps` to install because it uses a higher version